### PR TITLE
Fix ignored max and state filter in getIssuesByAgile

### DIFF
--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -70,7 +70,7 @@ export class ApiService {
   getIssuesByAgile = (agileName) => {
     return new Promise(resolve => {
       this.UseAccount().then(() => {
-        this.http.get('/rest/issue?filter=for:me+Board+' + agileName + ':+{Current+sprint}+#Unresolved&max=50')
+        this.http.get('/rest/issue?filter=for:me+Board+' + agileName + ':+{Current+sprint}+-Resolved&max=50')
           .map(res => res.json())
           .subscribe(data => {
             resolve(data)


### PR DESCRIPTION
The '#' in '#Unresolved' isn't escaped which causes YouTrack to ignore the state filter and max parameter. '#Unresolved' can be replaced with the equivalent '-Resolved' to solve this.